### PR TITLE
refactor(rich/logging): remove pino-pretty from logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev",
+    "dev": "nuxt dev | pino-pretty",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
@@ -30,7 +30,6 @@
     "pg": "^8.16.3",
     "pinia": "^3.0.3",
     "pino": "^9.11.0",
-    "pino-pretty": "^13.1.1",
     "primevue": "^4.3.9",
     "rabbitmq-client": "^5.0.5",
     "socket.io": "^4.8.1",
@@ -47,6 +46,7 @@
     "@types/object-hash": "^3.0.6",
     "@types/pg": "^8.15.5",
     "drizzle-kit": "^0.31.4",
+    "pino-pretty": "^13.1.1",
     "typescript": "^5.9.2",
     "vue-tsc": "^3.0.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       pino:
         specifier: ^9.11.0
         version: 9.11.0
-      pino-pretty:
-        specifier: ^13.1.1
-        version: 13.1.1
       primevue:
         specifier: ^4.3.9
         version: 4.3.9(vue@3.5.22(typescript@5.9.2))
@@ -105,6 +102,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.4
+      pino-pretty:
+        specifier: ^13.1.1
+        version: 13.1.1
       typescript:
         specifier: ^5.9.2
         version: 5.9.2

--- a/shared/logger.ts
+++ b/shared/logger.ts
@@ -1,17 +1,8 @@
 import {pino} from "pino";
-import 'pino-pretty';
 
 export default function Logger(name: string) {
   return pino({
     name: name,
     level: process.env.LOG_LEVEL || "info",
-    transport: {
-      target: 'pino-pretty',
-      options: {
-        colorize: true,
-        levelFirst: true,
-        translateTime: 'HH:MM:ss',
-      },
-    }
   });
 }


### PR DESCRIPTION
Moved pretty printing configuration to dev script
and updated dependencies accordingly.
Uses pino-pretty via pipe in dev mode instead.

Closes: rich/logging