### PR TITLE
refactor(rich/logging): conditionally enable devtools

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,7 +26,9 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   compatibilityDate: "2025-07-15",
-  devtools: { enabled: true },
+  $development: {
+    devtools: {enabled: true},
+  },
   nitro: {
     experimental: {
       websocket: true,


### PR DESCRIPTION
Moved devtools configuration inside $development block to only enable in development environment.

Closes: rich/logging