### PR TITLE
feat(rich/logging): configure pnpm workspace dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "mysql2": "^3.15.1",
     "nuxt": "^4.1.2",
     "object-hash": "^3.0.0",
+    "perfect-debounce": "^2.0.0",
     "pg": "^8.16.3",
     "pinia": "^3.0.3",
     "pino": "^9.11.0",
+    "pino-pretty": "^13.1.1",
     "primevue": "^4.3.9",
     "rabbitmq-client": "^5.0.5",
     "socket.io": "^4.8.1",
@@ -46,7 +48,6 @@
     "@types/object-hash": "^3.0.6",
     "@types/pg": "^8.15.5",
     "drizzle-kit": "^0.31.4",
-    "pino-pretty": "^13.1.1",
     "typescript": "^5.9.2",
     "vue-tsc": "^3.0.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
+      perfect-debounce:
+        specifier: ^2.0.0
+        version: 2.0.0
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -59,6 +62,9 @@ importers:
       pino:
         specifier: ^9.11.0
         version: 9.11.0
+      pino-pretty:
+        specifier: ^13.1.1
+        version: 13.1.1
       primevue:
         specifier: ^4.3.9
         version: 4.3.9(vue@3.5.22(typescript@5.9.2))
@@ -102,9 +108,6 @@ importers:
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.4
-      pino-pretty:
-        specifier: ^13.1.1
-        version: 13.1.1
       typescript:
         specifier: ^5.9.2
         version: 5.9.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@prisma/client'
+  - '@prisma/engines'
+  - '@tailwindcss/oxide'
+  - esbuild
+  - prisma

--- a/shared/logger.ts
+++ b/shared/logger.ts
@@ -1,8 +1,17 @@
 import {pino} from "pino";
+import 'pino-pretty';
 
 export default function Logger(name: string) {
   return pino({
     name: name,
     level: process.env.LOG_LEVEL || "info",
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        colorize: true,
+        levelFirst: true,
+        translateTime: 'HH:MM:ss',
+      },
+    }
   });
 }


### PR DESCRIPTION
Added onlyBuiltDependencies configuration
to specify which packages should be built
during workspace installation.
Includes @parcel/watcher, @prisma/client,
@prisma/engines, @tailwindcss/oxide,
esbuild, and prisma.