### PR TITLE
Admin list all queue items

### DIFF
--- a/app/pages/QueryRunner.client.vue
+++ b/app/pages/QueryRunner.client.vue
@@ -164,9 +164,6 @@ async function refresh() {
         page: page.value,
         size: rows.value,
       },
-      headers: {
-        Authorization: `Bearer ${useCookie("casdoor_access_token")}`,
-      },
     }
   );
   if (results) {

--- a/models/User.ts
+++ b/models/User.ts
@@ -6,7 +6,8 @@ export const userSchema = z.object({
   displayName: z.string(),
   email: z.string(),
   avatar: z.string(),
-  type: z.string()
+  type: z.string(),
+  groups: z.array(z.string())
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/public/casbin/policy.csv
+++ b/public/casbin/policy.csv
@@ -12,6 +12,4 @@ p, true, /, *, allow
 p, true, /login, *, allow
 p, true, /callback, *, allow
 p, true, /unauthorized, *, allow
-p, (r.sub != null) && (r.sub.userName == 'rcollier'), /QueryRunner, *, allow
-p, (r.sub != null) && (r.sub.userName == 'mattergosoft'), /QueryRunner, *, allow
-p, (r.sub != null) && (r.sub.age > 18), /QueryRunner, *, allow
+p, (r.sub != null) && ('Endeavour/Admin' in (r.sub.groups)), /QueryRunner, *, allow

--- a/server/api/queue/user/index.get.ts
+++ b/server/api/queue/user/index.get.ts
@@ -2,7 +2,7 @@ import z from "zod";
 import {pgQueueItemSelect, postgresDb} from "~~/server/db/postgres";
 import {queueItem} from "~~/server/db/postgres/schema";
 import {desc, eq} from "drizzle-orm";
-
+import Logger from "#shared/logger";
 
 const querySchema = z.object({
   page: z.coerce.number().default(1),
@@ -11,6 +11,8 @@ const querySchema = z.object({
 });
 
 export default defineEventHandler(async (event) => {
+  const LOG = Logger("api/queue/user");
+
   globalThis.io.to('test-room').emit("message", "Hello from server!");
 
   const { page, size, userId } = await getValidatedQuery(
@@ -19,12 +21,21 @@ export default defineEventHandler(async (event) => {
   );
 
   const totalCount = await postgresDb.$count(queueItem, eq(queueItem.userId, userId));
-  const rs = await postgresDb.query.queueItem.findMany({
-    where: eq(queueItem.userId, userId),
-    orderBy: [desc(queueItem.queuedAt)],
-    offset: (+page - 1) * +size,
-    limit: size,
-  });
+
+  let qry = postgresDb.select()
+    .from(queueItem)
+    .orderBy(desc(queueItem.queuedAt))
+    .offset((+page - 1) * +size)
+    .limit(size);
+
+  const user = globalThis.authenticator.getUser(event);
+  if (!user?.groups.includes("Endeavour/Admin")) {
+    qry.where(eq(queueItem.userId, userId));
+  }
+
+  LOG.trace(qry.toSQL())
+
+  const rs = await qry.execute();
 
   const items = rs.map((row) => pgQueueItemSelect.parse(row));
 

--- a/server/db/postgres.ts
+++ b/server/db/postgres.ts
@@ -2,7 +2,6 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import * as schema from "./postgres/schema"
 import {createInsertSchema, createSelectSchema} from "drizzle-zod";
 import {queueItem} from "./postgres/schema";
-import z from "zod";
 
 export const postgresDb = drizzle(process.env.POSTGRES_URL!, { schema });
 export const pgQueueItemInsert = createInsertSchema(queueItem);

--- a/server/utils/security/auth/auth.casdoor.ts
+++ b/server/utils/security/auth/auth.casdoor.ts
@@ -44,7 +44,8 @@ export default class Casdoor extends Authenticator {
       userName: casdoorUser.name,
       displayName: casdoorUser.displayName,
       email: casdoorUser.email,
-      avatar: casdoorUser.avatar
+      avatar: casdoorUser.avatar,
+      groups: casdoorUser.groups
     } as User;
   }
   async revokeTokens(event: H3Event<EventHandlerRequest>, accessToken? :string, refreshToken?: string): Promise<void> {
@@ -59,16 +60,24 @@ export default class Casdoor extends Authenticator {
   async requireUserInternal(event: H3Event<EventHandlerRequest>, accessToken? :string, refreshToken?: string): Promise<void> {
     if (!accessToken)
       throw createError({ status: 401, message: "Missing access token cookie" });
+
+    this.LOG.debug("Introspecting access token")
     const response = await this.casdoor.introspect(accessToken, "access_token");
+
+    this.LOG.debug("Response [" + response.data.active + "]")
+
     if (!response.data.active) {
       await this.logout(event);
-      throw createError({ status: 401, message: "Invalid token" });
+      throw createError({ status: 401, message: "Inactive token" });
     } else if (refreshToken) {
+      this.LOG.debug("Introspecting refresh token")
       const refreshResponse = await this.casdoor.introspect(
-        accessToken,
+        refreshToken,
         "refresh_token"
       );
+
       if (!refreshResponse.data.active) {
+        this.LOG.error("Inactive refresh token")
         await this.logout(event);
         throw createError({status: 401, message: "Invalid refresh token"});
       }

--- a/server/utils/security/guard/guard.casbin.ts
+++ b/server/utils/security/guard/guard.casbin.ts
@@ -27,7 +27,9 @@ export class GuardCasbin implements Guard {
       this.LOG.debug(`[${permission[1]}]`);
       return permission[0].valueOf();
     } catch (error: any) {
-      this.LOG.error("API: Error checking permissions:", error);
+      this.LOG.error("API: Error checking permissions:");
+      this.LOG.error(error);
+      console.error(error);
 
       throw new AuthorizationError({
         code: 401,


### PR DESCRIPTION
refactor(auth): add groups to user model and auth flow

Enhanced user authentication to include group information from Casdoor. Updated token introspection logic
to properly validate refresh tokens.
Added logging for token validation steps.

feat(api): implement group-based access control for queue items

Modified queue item retrieval to filter results based on user groups. Admin users can now view all items,
while regular users only see their own.
Updated Casbin policy to use group-based permissions.

fix(types): update user schema with groups field

Added groups array to User type definition
to support group-based authorization features.
This change ensures type safety for group-related operations.

Closes: rich/admin-list