### PR TITLE
refactor(api): enhance queue item filtering with date support

### DIFF
--- a/app/components/queryRunner/QueryResults.vue
+++ b/app/components/queryRunner/QueryResults.vue
@@ -14,6 +14,7 @@
   >
     <div class="query-results-dialog-content">
       <DataTable
+        :size="'small'"
         :value="queryResults"
         :paginator="true"
         :rows="size"

--- a/server/api/queue/user/index.get.ts
+++ b/server/api/queue/user/index.get.ts
@@ -1,39 +1,41 @@
 import z from "zod";
 import {pgQueueItemSelect, postgresDb} from "~~/server/db/postgres";
 import {queueItem} from "~~/server/db/postgres/schema";
-import {desc, eq} from "drizzle-orm";
+import {and, desc, eq, lte, SQL} from "drizzle-orm";
 import Logger from "#shared/logger";
 
 const querySchema = z.object({
   page: z.coerce.number().default(1),
   size: z.coerce.number().default(25),
+  date: z.iso.date().optional(),
   userId: z.string(),
 });
 
 export default defineEventHandler(async (event) => {
   const LOG = Logger("api/queue/user");
+  const user = globalThis.authenticator.getUser(event);
 
-  globalThis.io.to('test-room').emit("message", "Hello from server!");
-
-  const { page, size, userId } = await getValidatedQuery(
+  const { page, size, userId, date } = await getValidatedQuery(
     event,
     querySchema.parse
   );
 
   const totalCount = await postgresDb.$count(queueItem, eq(queueItem.userId, userId));
 
+  const filters: SQL[] = [];
+  // if (!user?.groups.includes("Endeavour/Admin"))
+    filters.push(eq(queueItem.userId, userId));
+  if (date)
+    filters.push(lte(queueItem.queuedAt, date));
+
   let qry = postgresDb.select()
     .from(queueItem)
+    .where(and(...filters))
     .orderBy(desc(queueItem.queuedAt))
     .offset((+page - 1) * +size)
     .limit(size);
 
-  const user = globalThis.authenticator.getUser(event);
-  if (!user?.groups.includes("Endeavour/Admin")) {
-    qry.where(eq(queueItem.userId, userId));
-  }
-
-  LOG.trace(qry.toSQL())
+  LOG.debug(qry.toSQL().sql)
 
   const rs = await qry.execute();
 


### PR DESCRIPTION
Added optional date parameter to queue item retrieval API. Implemented date-based filtering using Drizzle ORM's lte function. Updated query logic to use AND conditions for multiple filters. Improved logging output format for better debugging.

Closes: rich/admin-list