### PR TITLE
refactor(api): replace useFetch with $fetch for query operations

### DIFF
--- a/app/components/queryRunner/QueryResults.vue
+++ b/app/components/queryRunner/QueryResults.vue
@@ -82,10 +82,10 @@ async function getQueryResults() {
   if (props.queryId) {
     // request.page = { pageNumber: pageNumber.value, pageSize: size.value }; //TODO: fix paging mechanism
     //const results = await useFetch(`/api/queue/query/results/hashcode/1); //TODO: for testing, remove later
-    const results = await useFetch(`/api/queue/query/results/${props.queryId}`);
-    if (results.data.value && isArray(results.data.value)) {
-      totalCount.value = results.data.value.length; //TODO: replace with actual count
-      queryResults.value = results.data.value;
+    const value = await $fetch(`/api/queue/query/results/${props.queryId}`);
+    if (value && isArray(value)) {
+      totalCount.value = value.length; //TODO: replace with actual count
+      queryResults.value = value;
     }
   }
 }

--- a/app/pages/QueryRunner.client.vue
+++ b/app/pages/QueryRunner.client.vue
@@ -209,7 +209,7 @@ function getStatusSeverity(
 }
 
 async function cancelQuery(queryId: string) {
-  await useFetch(`/api/queue/query/cancel/${queryId}`);
+  await $fetch(`/api/queue/query/cancel/${queryId}`);
   await refresh();
 }
 
@@ -251,14 +251,14 @@ function runQuery() {
 }
 
 async function deleteQuery(queryId: string) {
-  await useFetch(`/api/queue/query/delete/${queryId}`);
+  await $fetch(`/api/queue/query/delete/${queryId}`);
   await refresh();
 }
 
 async function requeueQuery(queryId: string) {
   const found = getById(queryId);
   if (found)
-    await useFetch("/api/queue/query/requeue", {
+    await $fetch("/api/queue/query/requeue", {
       method: "post",
       body: found,
     });

--- a/app/pages/run.client.vue
+++ b/app/pages/run.client.vue
@@ -44,7 +44,7 @@ const request: any = {
 const showDialog = ref(false);
 
 async function runQuery() {
-  await useFetch("/api/queue/query/add", {
+  await $fetch("/api/queue/query/add", {
     method: "post",
     body: {
       "query": {

--- a/server/db/mysql/0000_create_tables.sql
+++ b/server/db/mysql/0000_create_tables.sql
@@ -25,19 +25,21 @@ SET `parent` = @s,
 DROP TABLE IF EXISTS `compass`.`cohort`;
 
 CREATE TABLE `compass`.`cohort` (
-  `dbid` INT NOT NULL,
-  `hash` INT NOT NULL,
-  `cohort_id` INT NOT NULL,
-  UNIQUE KEY `uq_hash_cohort` (`hash`, `cohort_id`),
-  PRIMARY KEY (`dbid`));
+    `dbid` INT AUTO_INCREMENT,
+    `hash` BIGINT NOT NULL,
+    `cohort_id` INT NOT NULL,
+    UNIQUE KEY `uq_hash_cohort` (`hash`, `cohort_id`),
+    PRIMARY KEY (`dbid`)
+);
 
 DROP TABLE IF EXISTS `compass`.`dataset`;
 
 CREATE TABLE `compass`.`dataset` (
-  `dbid` INT NOT NULL,
-  `hash` INT NOT NULL,
+  `dbid` INT AUTO_INCREMENT,
+  `hash` BIGINT NOT NULL,
   `cohort_id` INT NOT NULL,
   `group` VARCHAR(45) NOT NULL,
   `json` JSON NULL,
   UNIQUE KEY `uq_dataset` (`hash`, `cohort_id`, `group`),
-  PRIMARY KEY (`dbid`));
+  PRIMARY KEY (`dbid`)
+);


### PR DESCRIPTION
Updated API calls in QueryRunner component to use $fetch instead of useFetch for query cancellation, deletion, and requeuing operations. Also updated results fetching logic to use $fetch and simplified data handling.

Changed database schema to use BIGINT for hash fields and AUTO_INCREMENT for dbid in cohort and dataset tables.
- Modified cohort table: changed dbid to AUTO_INCREMENT, hash to BIGINT
- Modified dataset table: changed dbid to AUTO_INCREMENT, hash to BIGINT