### PR TITLE
refactor(db): migrate Drizzle ORM queries to standard API and simplify schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This is a **Nuxt 3** (Full-stack) application utilizing a producer-consumer architecture for Information Model (IM) query execution.
+
+- **[./app/](./app/)**: Frontend (Vue 3, Pinia, PrimeVue). Follows standard Nuxt structure.
+- **[./server/](./server/)**: Backend (Nitro). Contains API endpoints, Drizzle ORM configurations, and RabbitMQ integration.
+- **[./models/](./models/)**: Shared Zod schemas and TypeScript interfaces for both frontend and backend validation.
+- **[./docker/](./docker/)**: Infrastructure setup for local development (MySQL, PostgreSQL, RabbitMQ, Casdoor).
+
+The application uses **RabbitMQ** to handle long-running query jobs. The producer logic is typically in `server/api/queue/` while consumers are in `server/rabbitmq/`.
+
+## Build, Test, and Development Commands
+Use `pnpm` as the package manager.
+
+- **Dev**: `pnpm dev`
+- **Build**: `pnpm build`
+- **Tests**: `pnpm test:unit`
+- **Type Check**: `npx vue-tsc`
+- **Database Schema Sync**:
+  - `pnpm drizzle-pull`: Pulls both Postgres and MySQL schemas.
+  - `pnpm drizzle-pull-postgres`: Pulls only Postgres.
+  - `pnpm drizzle-pull-mysql`: Pulls only MySQL.
+
+## Coding Style & Naming Conventions
+- **TypeScript**: Strictly enforced; `typescript.typeCheck` is enabled in `nuxt.config.ts`.
+- **Validation**: Use **Zod** for all API request/response validation.
+- **UI**: Components use **PrimeVue** with **Tailwind CSS** for styling.
+- **State Management**: Use **Pinia** stores in `app/stores/`.
+- **Database**: Use **Drizzle ORM** for database interactions.
+
+## Testing Guidelines
+- **Framework**: **Vitest** is used for unit testing.
+- **Location**: Tests are located in `tests/unit/`.
+- **Run all tests**: `pnpm test:unit`
+
+## Commit & Pull Request Guidelines
+- **Commit Messages**: Follow conventional commits (e.g., `feat:`, `fix:`, `refactor:`, `docs:`).
+- **Patterns**: Recent history shows a preference for concise messages and merging via Pull Requests (e.g., `Merge pull request #XX from ...`).

--- a/DEVELOPERS.MD
+++ b/DEVELOPERS.MD
@@ -1,0 +1,70 @@
+# Developer Overview - IMQueryRunner
+
+Welcome to the **IMQueryRunner** development documentation. This document provides a structural and technical overview of the project to help developers get started quickly.
+
+## Project Overview
+
+IMQueryRunner is a full-stack application built with **Nuxt 3** designed to manage, execute, and monitor Information Model (IM) queries. It integrates with an external IMAPI for SQL generation and uses a queue-based system for job execution.
+
+## Tech Stack
+
+- **Framework**: [Nuxt 3](https://nuxt.com/) (Vue 3, Nitro)
+- **Frontend**:
+  - **UI Components**: [PrimeVue](https://primevue.org/)
+  - **Styling**: [Tailwind CSS](https://tailwindcss.com/)
+  - **State Management**: [Pinia](https://pinia.vuejs.org/)
+- **Backend**:
+  - **ORM**: [Drizzle ORM](https://orm.drizzle.team/) (MySQL & PostgreSQL support)
+  - **Queue**: [RabbitMQ](https://www.rabbitmq.com/) via `rabbitmq-client`
+  - **API**: Nitro (built into Nuxt)
+- **Validation**: [Zod](https://zod.dev/)
+- **Testing**: [Vitest](https://vitest.dev/)
+- **Authentication**: Casdoor & AWS Cognito
+
+## Directory Structure
+
+| Directory | Description |
+|-----------|-------------|
+| [./app/](./app/) | Frontend source code (components, pages, stores, layouts). |
+| [./server/](./server/) | Backend source code (API endpoints, DB config, RabbitMQ logic, middleware). |
+| [./models/](./models/) | Shared TypeScript interfaces and Zod schemas. |
+| [./enums/](./enums/) | Project-wide enumerations (e.g., JobStatus, Resource). |
+| [./docker/](./docker/) | Infrastructure setup scripts for MySQL, PostgreSQL, RabbitMQ, and Casdoor. |
+| [./shared/](./shared/) | Common utilities like loggers and global type definitions. |
+| [./tests/](./tests/) | Unit and integration tests. |
+| [./docs/](./docs/) | Project documentation and specifications. |
+
+## Key Architectural Patterns
+
+### 1. Job Queue System
+The application uses a producer-consumer pattern for long-running queries:
+- **Producer**: API endpoints in [./server/api/queue/job/add.post.ts](./server/api/queue/job/add.post.ts) add jobs to RabbitMQ.
+- **Consumer**: Background tasks/plugins in `server/rabbitmq/` or `server/tasks/` process these jobs.
+- **Status Tracking**: Job states are updated in the database and can be monitored via [./server/api/queue/index.get.ts](./server/api/queue/index.get.ts).
+
+### 2. Database Layer
+The project uses **Drizzle ORM** with support for multiple database engines. 
+- Schemas are defined in [./models/](./models/) (often using `drizzle-zod` for validation).
+- Connection configurations are located in [./server/db/](./server/db/).
+
+### 3. API Integration (IMAPI)
+Integration with the core Information Model API is handled in [./server/api/imapi/](./server/api/imapi/). This includes:
+- Converting IMQ (Information Model Query) to SQL.
+- Fetching query metadata and children.
+
+## Getting Started
+
+### Prerequisites
+- Node.js (v18+)
+- pnpm
+- Docker (for local database and RabbitMQ setup)
+
+### Setup Commands
+- **Install dependencies**: `pnpm install`
+- **Start infrastructure**: Use scripts in `./docker/` to spin up required containers.
+- **Development mode**: `pnpm dev`
+- **Run tests**: `pnpm test:unit`
+
+## Useful Links
+- [Specification](./Specification.md) - Functional requirements and TODOs.
+- [Drizzle Kit](./package.json) - Check scripts for `drizzle-pull` to sync DB schemas.

--- a/server/api/queue/job/[jobId].delete.ts
+++ b/server/api/queue/job/[jobId].delete.ts
@@ -1,8 +1,8 @@
-import { mysqlDb } from "~~/server/db/mysql";
-import { jobTable } from "~~/server/db/mysql/schema";
-
 import { eq } from "drizzle-orm";
 import * as z from "zod";
+
+import { mysqlDb } from "../../../db/mysql";
+import { jobTable } from "../../../db/mysql/schema";
 
 const paramSchema = z.object({
   jobId: z.string()
@@ -11,9 +11,11 @@ const paramSchema = z.object({
 export default defineEventHandler(async event => {
   const { jobId } = await getValidatedRouterParams(event, paramSchema.parse);
   console.log("Deleting job with ID:", jobId);
-  const item = await mysqlDb.query.jobTable.findFirst({
-    where: eq(jobTable.id, Number(jobId))
-  });
+  const items = await mysqlDb
+    .select()
+    .from(jobTable)
+    .where(eq(jobTable.id, Number(jobId)));
+  const item = items[0];
   if (item) {
     await mysqlDb.delete(jobTable).where(eq(jobTable.id, item.id));
   } else {

--- a/server/api/queue/job/[jobId].get.ts
+++ b/server/api/queue/job/[jobId].get.ts
@@ -10,9 +10,11 @@ const paramSchema = z.object({
 
 export default defineEventHandler(async event => {
   const { jobId } = await getValidatedRouterParams(event, paramSchema.parse);
-  const item = await mysqlDb.query.jobTable.findFirst({
-    where: eq(jobTable.id, Number(jobId))
-  });
+  const items = await mysqlDb
+    .select()
+    .from(jobTable)
+    .where(eq(jobTable.id, Number(jobId)));
+  const item = items[0];
 
   return item;
 });

--- a/server/api/queue/job/results/[jobId]/[queryType]/[queryIri].get.ts
+++ b/server/api/queue/job/results/[jobId]/[queryType]/[queryIri].get.ts
@@ -1,5 +1,5 @@
 import { mysqlDb } from "~~/server/db/mysql";
-import { cohortResultsTable, datasetResultsTable } from "~~/server/db/mysql/schema";
+import { cohortResultsTable, datasetResultsTable, indicatorResultTable, queryResultSetTable, queryResultTable } from "~~/server/db/mysql/schema";
 
 import { IMQType } from "@endeavour/vue-library";
 
@@ -23,9 +23,11 @@ export default defineEventHandler(async event => {
   const decodedQueryIri = decodeURIComponent(queryIri);
   // TODO: Refactor to use a single query with joins instead of multiple queries
 
-  const queryResultSet = await mysqlDb.query.queryResultSetTable.findFirst({
-    where: q => and(eq(q.jobId, Number(jobId)), eq(q.queryIri, decodedQueryIri))
-  });
+  const queryResultSetRows = await mysqlDb
+    .select()
+    .from(queryResultSetTable)
+    .where(and(eq(queryResultSetTable.jobId, Number(jobId)), eq(queryResultSetTable.queryIri, decodedQueryIri)));
+  const queryResultSet = queryResultSetRows[0];
   if (!queryResultSet) {
     throw createError("Query result set not found");
   }
@@ -39,15 +41,19 @@ export default defineEventHandler(async event => {
   };
 
   if (queryType === IMQType.INDICATOR) {
-    const indicatorResult = await mysqlDb.query.indicatorResultTable.findFirst({
-      where: q => and(eq(q.queryIri, decodedQueryIri), eq(q.queryResultSetId, queryResultSet.id))
-    });
+    const indicatorResultRows = await mysqlDb
+      .select()
+      .from(indicatorResultTable)
+      .where(and(eq(indicatorResultTable.queryIri, decodedQueryIri), eq(indicatorResultTable.queryResultSetId, queryResultSet.id)));
+    const indicatorResult = indicatorResultRows[0];
     // TODO: return indicator results - get sql from imapi
     return returnObject;
   } else {
-    const queryResult = await mysqlDb.query.queryResultTable.findFirst({
-      where: q => and(eq(q.queryIri, decodedQueryIri), eq(q.queryResultSetId, queryResultSet.id))
-    });
+    const queryResultRows = await mysqlDb
+      .select()
+      .from(queryResultTable)
+      .where(and(eq(queryResultTable.queryIri, decodedQueryIri), eq(queryResultTable.queryResultSetId, queryResultSet.id)));
+    const queryResult = queryResultRows[0];
 
     if (!queryResult) {
       throw createError("Query result not found");
@@ -55,22 +61,14 @@ export default defineEventHandler(async event => {
 
     if (queryType === IMQType.COHORT) {
       const whereClause = eq(cohortResultsTable.queryResultId, queryResult.id);
-      const cohortResults = await mysqlDb.query.cohortResultsTable.findMany({
-        where: whereClause,
-        limit,
-        offset
-      });
+      const cohortResults = await mysqlDb.select().from(cohortResultsTable).where(whereClause).limit(limit).offset(offset);
       const totalResult = await mysqlDb.select({ count: count() }).from(cohortResultsTable).where(whereClause);
       const totalCount = totalResult[0]?.count ?? 0;
       returnObject.result = cohortResults;
       returnObject.totalCount = totalCount;
     } else if (queryType === IMQType.DATASET) {
       const whereClause = eq(datasetResultsTable.queryResultId, queryResult.id);
-      const datasetResults = await mysqlDb.query.datasetResultsTable.findMany({
-        where: whereClause,
-        limit,
-        offset
-      });
+      const datasetResults = await mysqlDb.select().from(datasetResultsTable).where(whereClause).limit(limit).offset(offset);
       const totalResult = await mysqlDb.select({ count: count() }).from(datasetResultsTable).where(whereClause);
       const totalCount = totalResult[0]?.count ?? 0;
       returnObject.result = datasetResults;

--- a/server/api/queue/job/stop/[jobId].ts
+++ b/server/api/queue/job/stop/[jobId].ts
@@ -12,9 +12,11 @@ const paramSchema = z.object({
 
 export default defineEventHandler(async event => {
   const { jobId } = await getValidatedRouterParams(event, paramSchema.parse);
-  const item = await mysqlDb.query.jobTable.findFirst({
-    where: eq(jobTable.id, Number(jobId))
-  });
+  const items = await mysqlDb
+    .select()
+    .from(jobTable)
+    .where(eq(jobTable.id, Number(jobId)));
+  const item = items[0];
   const now = getNow();
 
   if (item?.status === JobStatus.QUEUED) {

--- a/server/db/mysql.ts
+++ b/server/db/mysql.ts
@@ -1,12 +1,13 @@
-import * as schema from "~~/server/db/mysql/schema";
+import { MySql2Database, drizzle } from "drizzle-orm/mysql2";
 
-import { drizzle } from "drizzle-orm/mysql2";
+import * as schema from "./mysql/schema";
 
 if (!process.env.COMPASS_URL) {
   throw new Error("Missing COMPASS_URL environment variable");
 }
 
-export const mysqlDb = drizzle(process.env.COMPASS_URL, {
+export const mysqlDb: MySql2Database<typeof schema> = drizzle({
+  connection: process.env.COMPASS_URL,
   schema,
   mode: "default"
 });

--- a/server/db/mysql/relations.ts
+++ b/server/db/mysql/relations.ts
@@ -1,3 +1,3 @@
-import { relations } from "drizzle-orm/relations";
+import { defineRelations } from "drizzle-orm";
 
 import "./schema";

--- a/server/db/mysql/schema.ts
+++ b/server/db/mysql/schema.ts
@@ -37,7 +37,7 @@ export const jobTable = mysqlTable(
     status: varchar("status", { length: 45 }).$type<JobStatus>().notNull(),
     error: json("error")
   },
-  table => [primaryKey({ columns: [table.id], name: "id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const queryResultSetTable = mysqlTable(
@@ -54,7 +54,7 @@ export const queryResultSetTable = mysqlTable(
     achievementDate: date("achievement_date", { mode: "string" }),
     jobId: int("job_id").notNull()
   },
-  table => [primaryKey({ columns: [table.id], name: "id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const indicatorResultTable = mysqlTable(
@@ -72,7 +72,7 @@ export const indicatorResultTable = mysqlTable(
     useStartOfDaySnapshot: tinyint("use_start_of_day_snapshot").notNull(),
     version: int("version").notNull()
   },
-  table => [primaryKey({ columns: [table.id], name: "id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const queryResultTable = mysqlTable(
@@ -91,7 +91,7 @@ export const queryResultTable = mysqlTable(
     useStartOfDaySnapshot: tinyint("use_start_of_day_snapshot").notNull(),
     version: int("version").notNull()
   },
-  table => [primaryKey({ columns: [table.id], name: "id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const datasetResultsTable = mysqlTable("dataset`.`dataset_results", {
@@ -125,7 +125,7 @@ export const allergyIntolerance = mysqlTable(
     ageAtEvent: decimal("age_at_event", { precision: 5, scale: 2 }),
     dateRecorded: datetime("date_recorded", { mode: "string" })
   },
-  table => [primaryKey({ columns: [table.id], name: "allergy_intolerance_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const concept = mysqlTable(
@@ -146,8 +146,7 @@ export const concept = mysqlTable(
   },
   table => [
     index("concept_draft").on(table.draft),
-    primaryKey({ columns: [table.dbid], name: "concept_dbid" }),
-    primaryKey({ columns: [table.dbid], name: "concept_dbid" }),
+    primaryKey(table.dbid),
     unique("concept_id_uq").on(table.id),
     unique("concept_scheme_code_idx").on(table.scheme, table.code)
   ]
@@ -164,7 +163,7 @@ export const conceptMap = mysqlTable(
     id: int().autoincrement().notNull(),
     deleted: tinyint().default(0).notNull()
   },
-  table => [primaryKey({ columns: [table.id], name: "concept_map_id" }), unique("concept_map_uq").on(table.legacy, table.deleted, table.updated)]
+  table => [primaryKey(table.id), unique("concept_map_uq").on(table.legacy, table.deleted, table.updated)]
 );
 
 export const conceptSetMember = mysqlTable(
@@ -176,11 +175,7 @@ export const conceptSetMember = mysqlTable(
     im1Id: varchar({ length: 150 }).notNull(),
     self: boolean().default(false).notNull()
   },
-  table => [
-    index("idx_set_self").on(table.set, table.self),
-    index("idx_csm").on(table.im1Id, table.self),
-    primaryKey({ columns: [table.id], name: "concept_set_member_id" })
-  ]
+  table => [index("idx_set_self").on(table.set, table.self), index("idx_csm").on(table.im1Id, table.self), primaryKey(table.id)]
 );
 
 export const encounter = mysqlTable(
@@ -210,7 +205,7 @@ export const encounter = mysqlTable(
     institutionLocationId: text("institution_location_id"),
     dateRecorded: datetime("date_recorded", { mode: "string" })
   },
-  table => [primaryKey({ columns: [table.id], name: "encounter_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const episodeOfCare = mysqlTable(
@@ -230,7 +225,7 @@ export const episodeOfCare = mysqlTable(
       mode: "number"
     })
   },
-  table => [primaryKey({ columns: [table.id], name: "episode_of_care_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const medicationOrder = mysqlTable(
@@ -261,7 +256,7 @@ export const medicationOrder = mysqlTable(
     issueMethod: text("issue_method"),
     dateRecorded: datetime("date_recorded", { mode: "string" })
   },
-  table => [primaryKey({ columns: [table.id], name: "medication_order_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const medicationStatement = mysqlTable(
@@ -290,7 +285,7 @@ export const medicationStatement = mysqlTable(
     issueMethod: text("issue_method"),
     dateRecorded: datetime("date_recorded", { mode: "string" })
   },
-  table => [primaryKey({ columns: [table.id], name: "medication_statement_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const observation = mysqlTable(
@@ -324,7 +319,7 @@ export const observation = mysqlTable(
     isPrimary: tinyint("is_primary"),
     dateRecorded: datetime("date_recorded", { mode: "string" })
   },
-  table => [index("idx_obs").on(table.coreConceptId, table.clinicalEffectiveDate, table.patientId), primaryKey({ columns: [table.id], name: "observation_id" })]
+  table => [index("idx_obs").on(table.coreConceptId, table.clinicalEffectiveDate, table.patientId), primaryKey(table.id)]
 );
 
 export const patient = mysqlTable(
@@ -346,7 +341,7 @@ export const patient = mysqlTable(
     ethnicCodeConceptId: int("ethnic_code_concept_id"),
     registeredPracticeOrganizationId: bigint("registered_practice_organization_id", { mode: "number" })
   },
-  table => [primaryKey({ columns: [table.id], name: "patient_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const patientAddress = mysqlTable(
@@ -375,7 +370,7 @@ export const patientAddress = mysqlTable(
     localAuthorityCode: varchar("local_authority_code", { length: 9 }),
     townsendDeprivationIndex: double("townsend_deprivation_index")
   },
-  table => [primaryKey({ columns: [table.id], name: "patient_address_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const patientContact = mysqlTable(
@@ -393,7 +388,7 @@ export const patientContact = mysqlTable(
     endDate: date("end_date", { mode: "string" }),
     value: varchar({ length: 255 })
   },
-  table => [primaryKey({ columns: [table.id], name: "patient_contact_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const practitioner = mysqlTable(
@@ -406,7 +401,7 @@ export const practitioner = mysqlTable(
     roleDesc: varchar("role_desc", { length: 255 }),
     gmcCode: varchar("gmc_code", { length: 50 })
   },
-  table => [primaryKey({ columns: [table.id], name: "practitioner_id" })]
+  table => [primaryKey(table.id)]
 );
 
 export const smallPat = mysqlTable("compass.small_pat", {

--- a/server/helpers/mysqlHelper.ts
+++ b/server/helpers/mysqlHelper.ts
@@ -42,9 +42,8 @@ export async function createJobEntry(jobRequest: JobRequest, sessionId: string, 
 }
 
 export async function getJobById(jobId: number): Promise<Job> {
-  const job = await mysqlDb.query.jobTable.findFirst({
-    where: eq(jobTable.id, jobId)
-  });
+  const jobs = await mysqlDb.select().from(jobTable).where(eq(jobTable.id, jobId));
+  const job = jobs[0];
   if (!job) {
     throw new Error("Could not find job with id: " + jobId);
   }

--- a/server/utils/executeQuery.ts
+++ b/server/utils/executeQuery.ts
@@ -112,9 +112,11 @@ function hashArgument(argument: Argument): string {
 }
 
 export async function getQueryResultIdIfExists(resultSetId: number, hashCodeVersion: number, iri: string): Promise<number> {
-  const result = await mysqlDb.query.queryResultTable.findFirst({
-    where: queryResultTable => and(eq(queryResultTable.id, resultSetId), eq(queryResultTable.version, hashCodeVersion), eq(queryResultTable.queryIri, iri))
-  });
+  const results = await mysqlDb
+    .select()
+    .from(queryResultTable)
+    .where(and(eq(queryResultTable.id, resultSetId), eq(queryResultTable.version, hashCodeVersion), eq(queryResultTable.queryIri, iri)));
+  const result = results[0];
   console.log(`Cache context check (${!!result}): ${resultSetId} with hash: ${hashCodeVersion}, iri: ${iri}.`);
   return result ? result.id! : -1;
 }


### PR DESCRIPTION
- Replaced deprecated `query.table.findFirst` and `findMany` methods with explicit `select().from().where()` syntax across API endpoints and utilities.
- Simplified Drizzle schema definitions by using shorthand `primaryKey(table.column)` instead of verbose objects.
- Updated imports and typing for `mysqlDb` instance to use `MySql2Database` with explicit schema typing.
- Added `DEVELOPERS.md` and `AGENTS.md` documentation files for project structure and guidelines.